### PR TITLE
Allow coerce functions to take additional args

### DIFF
--- a/src/struct/core.cljc
+++ b/src/struct/core.cljc
@@ -103,7 +103,9 @@
           (recur skip errors data (rest steps))
 
           (apply-validation step data value)
-          (let [value ((:coerce step identity) value)]
+          (if-let [coerce (:coerce step)]
+            (let [value (apply coerce value (:args step []))]
+              (recur skip errors (assoc-in data path value) (rest steps)))
             (recur skip errors (assoc-in data path value) (rest steps)))
 
           :else

--- a/test/struct/tests.cljc
+++ b/test/struct/tests.cljc
@@ -102,6 +102,16 @@
     (t/is (= nil (first result)))
     (t/is (= {:max :foo :scope "foobar"} (second result)))))
 
+(t/deftest test-validation-with-custom-coersion-with-args
+  (let [default-fn (fn [v default] (or v default))
+        by-default {:optional false :coerce default-fn}
+        scheme {:limit [[by-default 200]]
+                :skip  [[by-default 0]]}
+        input {:limit 100}
+        result (st/validate input scheme)]
+    (t/is (= nil (first result)))
+    (t/is (= {:limit 100 :skip 0} (second result)))))
+
 (t/deftest test-validation-with-custom-message
   (let [scheme {:max [[st/number-str :message "custom msg"]]
                 :scope st/string}


### PR DESCRIPTION
I'm not sure in my implementation but I think it would be a great idea to allow coercing function to take more than one arg to implement, for example, by-default validator.
